### PR TITLE
Change dir before invoking Ag as CtrlP user command.

### DIFF
--- a/plugin/vimrc.vim
+++ b/plugin/vimrc.vim
@@ -280,7 +280,7 @@ set shortmess+=I
 let g:ctrlp_use_caching = 0
 if executable('ag')
     set grepprg=ag\ --nogroup\ --nocolor
-    let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
+    let g:ctrlp_user_command = 'cd %s && ag -l --nocolor -g ""'
 else
   let g:ctrlp_user_command = ['.git',
     \ 'cd %s && git ls-files . -co --exclude-standard',


### PR DESCRIPTION
I realized, after experiencing performance problems with CtrlP, that `Ag` doesn't honor .gitignore if it is not invoked in the repo root.
I tried invoking `ag` in both ways in command line and I can confirm it.
After this tiny change I got back the excellent CtrlP performance, so I'm sharing it.
